### PR TITLE
Basic client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+/vendor/
+
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in testrail-client.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    testrail-client (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.17)
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  testrail-client!
+
+BUNDLED WITH
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
+    hashdiff (1.0.0)
+    mustermann (1.0.3)
+    public_suffix (3.1.1)
+    rack (2.0.7)
+    rack-protection (2.0.5)
+      rack
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -21,6 +31,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    safe_yaml (1.0.5)
+    sinatra (2.0.5)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.5)
+      tilt (~> 2.0)
+    tilt (2.0.9)
+    webmock (3.6.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    yard (0.9.20)
 
 PLATFORMS
   ruby
@@ -29,7 +51,10 @@ DEPENDENCIES
   bundler (~> 1.17)
   rake (~> 10.0)
   rspec (~> 3.0)
+  sinatra (~> 2.0.5)
   testrail-client!
+  webmock (~> 3.6.2)
+  yard (~> 0.9.2)
 
 BUNDLED WITH
    1.17.3

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 Edmundo Sanchez
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Testrail::Client
+
+Based on [testrail_client](https://github.com/zachpendleton/testrail) and [testrail-ruby](https://gitlab.com/RubyAPITools/testrail-ruby) gems.
+
+Why? [testrail_client](https://github.com/zachpendleton/testrail) requires more setup and [testrail-ruby](https://gitlab.com/RubyAPITools/testrail-ruby) has a lot of missing endpoints which hard to maintain and time consuming to add.
+
+This gem provides both the Testrail::Client to send get and posts requests and an idiomatic interface for testrail v2 API, which ever sits better on you.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'testrail-client'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install testrail-client
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/testrail-client.
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "testrail/client"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/testrail/client.rb
+++ b/lib/testrail/client.rb
@@ -1,0 +1,90 @@
+require "testrail/client/version"
+require 'net/http'
+require 'net/https'
+require 'uri'
+require 'json'
+
+# @author Edmundo Sanchez
+module Testrail
+
+  module Client
+    class Request
+      attr_accessor :url
+      attr_accessor :user
+      attr_accessor :password
+      # Initialize Client
+      # @param base_url [String] Your Testrail URL
+      def initialize(base_url)
+        if !base_url.match(/\/$/)
+          base_url += '/'
+        end
+        @url = base_url + 'index.php?/api/v2/'
+        @content_type = "application/json"
+      end
+      # send GET to uri
+      # @param uri [String] Test rail API path
+      # @return [Hash] Response from testrail API
+      def send_get(uri)
+         request = _setup_request("GET",uri)
+        _send_request(request)
+      end
+      # send POST to uri
+      # @param uri [String] test rail API path
+      # @param data [Enumerable] data to be sent in the POST request
+      # @return [Hash] Response from testrail API
+      def send_post(uri, data = nil)
+        request = _setup_request('POST', uri, data)
+        _send_request(request)
+      end
+
+      private
+      # Setup NET::HTTP request object
+      # @param method [String] can be POST, GET, PUT, PATCH, or DELETE
+      # @param uri [String] test rail API path
+      # @param data [Enumerable] data to be sent in request
+      # @return [Net::HTTPRequest] Request object
+      def _setup_request(method,uri,data = nil)
+        url = URI.parse(@url + uri)
+        STDERR.puts "#{method} #{url}"
+        http_request = eval("Net::HTTP::#{method.capitalize}")
+        request = http_request.new(url)
+        request.add_field('Content-Type', @content_type)
+        request.body = JSON.dump(data) if data.is_a? Hash
+        request.set_form data, 'multipart/form-data' if data.is_a? Array
+        request.basic_auth(@user, @password)
+        return request
+      end
+
+      # Returns response from API
+      # @param request [Net::HTTPRequest] Request object created on _setup_request
+      # @return [Hash] Response from API
+      def _send_request(request)
+        conn = Net::HTTP.new(request.uri.host, request.uri.port)
+        if request.uri.scheme == 'https'
+          conn.use_ssl = true
+          conn.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        end
+        response = conn.request(request)
+
+        if response.body && !response.body.empty?
+          result = JSON.parse(response.body)
+        else
+          result = {}
+        end
+        if response.code != '200'
+          if result && result.key?('error')
+            error = '"' + result['error'] + '"'
+          else
+            error = 'No additional error message received'
+          end
+          raise APIError.new('TestRail API returned HTTP %s (%s)' %
+            [response.code, error])
+        end
+        result
+      end
+    end
+
+    class APIError < StandardError; end
+
+  end
+end

--- a/lib/testrail/client/version.rb
+++ b/lib/testrail/client/version.rb
@@ -1,0 +1,5 @@
+module Testrail
+  module Client
+    VERSION = "0.1.0"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
 require "bundler/setup"
+require 'webmock/rspec'
 require "testrail/client"
+require_relative "support/fake_testrails.rb"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
+  config.before(:each) do
+    stub_request(:any, /test.testrail.com\/index.php\?\/api\/v2/).to_rack(FakeTestRail)
+  end
   config.example_status_persistence_file_path = ".rspec_status"
-
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "testrail/client"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/spec/support/fake_testrails.rb
+++ b/spec/support/fake_testrails.rb
@@ -1,0 +1,21 @@
+require 'sinatra/base'
+
+class FakeTestRail < Sinatra::Base
+  get '/index.php' do
+    request.env.to_json
+  end
+  post '/index.php' do
+    #STDERR.puts request.body.read
+    str_body = request.body.read
+    unless str_body.empty?
+      request.env["BODY"] = JSON.parse(str_body)
+    end
+    request.env.to_json
+  end
+
+  not_found do
+    status 404
+    request.env.to_json
+  end
+
+end

--- a/spec/testrail/client_spec.rb
+++ b/spec/testrail/client_spec.rb
@@ -2,8 +2,76 @@ RSpec.describe Testrail::Client do
   it "has a version number" do
     expect(Testrail::Client::VERSION).not_to be nil
   end
+end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+RSpec.describe Testrail::Client::Request do
+  before :all do
+    base_url = "https://test.testrail.com/"
+    user     = "username"
+    password = "password"
+
+    @client = Testrail::Client::Request.new(base_url)
+    @client.user = user
+    @client.password = password
   end
+
+  it ".send_get" do
+    uri = "get_case/1"
+    response = @client.send_get(uri)
+    #STDERR.puts JSON.pretty_generate(response)
+    expect(response).to include(
+      "REQUEST_METHOD" => "GET",
+      "CONTENT_TYPE" => "application/json",
+      "PATH_INFO" => "/index.php",
+      "QUERY_STRING" => "/api/v2/get_case/1",
+      "SERVER_PORT" => 443,
+      "HTTP_ACCEPT_ENCODING" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "HTTP_ACCEPT" => "*/*",
+      "HTTP_USER_AGENT" => "Ruby",
+      "HTTP_HOST" => "test.testrail.com",
+      "HTTP_AUTHORIZATION" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+    )
+  end
+
+  it ".send_post" do
+    uri = "add_case/1"
+    response = @client.send_post(uri,{"foo": "bar", "biz": "baz"})
+    #STDERR.puts JSON.pretty_generate(response)
+    expect(response).to include(
+      "REQUEST_METHOD" => "POST",
+      "CONTENT_TYPE" => "application/json",
+      "PATH_INFO" => "/index.php",
+      "QUERY_STRING" => "/api/v2/add_case/1",
+      "SERVER_PORT" => 443,
+      "HTTP_ACCEPT_ENCODING" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "HTTP_ACCEPT" => "*/*",
+      "HTTP_USER_AGENT" => "Ruby",
+      "HTTP_HOST" => "test.testrail.com",
+      "HTTP_AUTHORIZATION" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+      "BODY" => {
+        "foo" => "bar",
+        "biz" => "baz"
+       }
+     )
+   end
+
+   it ".send_post (multipart form)" do
+     uri = "add_case/1"
+     file = File.dirname(__FILE__) + "/../../README.md"
+     response = @client.send_post(uri,[['attachment',File.open(file)]])
+     #STDERR.puts JSON.pretty_generate(response)
+     expect(response).to include(
+       "REQUEST_METHOD" => "POST",
+       "CONTENT_TYPE" => "multipart/form-data",
+       "PATH_INFO" => "/index.php",
+       "QUERY_STRING" => "/api/v2/add_case/1",
+       "SERVER_PORT" => 443,
+       "HTTP_ACCEPT_ENCODING" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+       "HTTP_ACCEPT" => "*/*",
+       "HTTP_USER_AGENT" => "Ruby",
+       "HTTP_HOST" => "test.testrail.com",
+       "HTTP_AUTHORIZATION" => "Basic dXNlcm5hbWU6cGFzc3dvcmQ=",
+      )
+  end
+
 end

--- a/spec/testrail/client_spec.rb
+++ b/spec/testrail/client_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Testrail::Client do
+  it "has a version number" do
+    expect(Testrail::Client::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/testrail-client.gemspec
+++ b/testrail-client.gemspec
@@ -1,0 +1,29 @@
+
+lib = File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require "testrail/client/version"
+
+Gem::Specification.new do |spec|
+  spec.name          = "testrail-client"
+  spec.version       = Testrail::Client::VERSION
+  spec.authors       = ["Edmundo Sanchez"]
+  spec.email         = ["zomundo@gmail.com"]
+
+  spec.summary       = "Another Client wrapper in Ruby for TestRail API (v2)"
+  spec.description   = "An easy to mantain gem that wrapps the v2 testrail API"
+  spec.homepage      = "https://github.com"
+  spec.license       = "MIT"
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+end

--- a/testrail-client.gemspec
+++ b/testrail-client.gemspec
@@ -23,7 +23,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.6.3'
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "sinatra", "~> 2.0.5"
+  spec.add_development_dependency 'webmock', "~> 3.6.2"
+  spec.add_development_dependency 'yard', "~> 0.9.2"
+
 end


### PR DESCRIPTION
setup basic REST client for he testrail API based on [zachpendleton/testrail](https://github.com/zachpendleton/testrail)

changes: 

1. Can use all REST verbs when creating NET::HTTPRequest object
1. Can use content_type = multipart/form-data for use on the attachments endpoints
1. Simple yardoc doc
1. Tested with rspec